### PR TITLE
Remove note about needing dev-route for CORS workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Then, using the console UI, from operator hub install the mtRHO Operator.
 
 *Note:* 
 - For now mtRHO and MTC are not compatible within a same namespace if installed using OLM and operator hub. 
-- To interact with UI properly, before creating `operatorConfig` CR, run `oc create -f https://raw.githubusercontent.com/konveyor/crane-reverse-proxy/main/dev-route.yml`. This route is a workaround of a CORS issue we are facing, there is a patch to resolve the same upstream as well, once that gets released we would no longer need to create this route.
 
 ## Custom Installation
 


### PR DESCRIPTION
See https://github.com/konveyor/crane-reverse-proxy/pull/15 and https://github.com/konveyor/crane-ui-plugin/pull/77. We no longer need this route in production because the upstream fix has been released and the CORS workarounds have been reverted.